### PR TITLE
Collector should only look for files under Validation, UnderReview, and Simulations.

### DIFF
--- a/APSIM.PerformanceTests.Collector/App.config
+++ b/APSIM.PerformanceTests.Collector/App.config
@@ -5,7 +5,7 @@
     <!-- For more information on Entity Framework configuration, visit http://go.microsoft.com/fwlink/?LinkID=237468 -->
   </configSections>
   <appSettings>
-    <add key="searchDirectory" value="C:/Jenkins/workspace/PullRequest_v2/ApsimX/Tests/"></add>
+    <add key="searchDirectory" value="C:/Jenkins/workspace/PullRequest_v2/ApsimX/Tests/UnderReview/;C:/Jenkins/workspace/PullRequest_v2/ApsimX/Tests/Validation/"></add>
     <add key="serviceAddress_apsim" value="http://www.apsim.info/"/>
     <add key="serviceAddress_csiro" value="https://apsim.csiro.au/"/>
   </appSettings>

--- a/APSIM.PerformanceTests.Collector/App.config
+++ b/APSIM.PerformanceTests.Collector/App.config
@@ -5,7 +5,7 @@
     <!-- For more information on Entity Framework configuration, visit http://go.microsoft.com/fwlink/?LinkID=237468 -->
   </configSections>
   <appSettings>
-    <add key="searchDirectory" value="C:/Jenkins/workspace/PullRequest_v2/ApsimX/Tests/UnderReview/;C:/Jenkins/workspace/PullRequest_v2/ApsimX/Tests/Validation/"></add>
+    <add key="searchDirectory" value="C:/Jenkins/workspace/PullRequest_v2/ApsimX/Tests/UnderReview/;C:/Jenkins/workspace/PullRequest_v2/ApsimX/Tests/Validation/;C:/Jenkins/workspace/PullRequest_v2/ApsimX/Tests/Simulation/"></add>
     <add key="serviceAddress_apsim" value="http://www.apsim.info/"/>
     <add key="serviceAddress_csiro" value="https://apsim.csiro.au/"/>
   </appSettings>


### PR DESCRIPTION
This will fix the issue where the collector tries to suck up some of the intentionally dodgy .apsimx files under the unit tests directory.