### PR TITLE
Fixed file count query in PR pass/fail evaluation

### DIFF
--- a/APSIM.PerformanceTests.Service/APSIM.PerformanceTests.Service/Controllers/AcceptStatsController.cs
+++ b/APSIM.PerformanceTests.Service/APSIM.PerformanceTests.Service/Controllers/AcceptStatsController.cs
@@ -66,9 +66,10 @@ namespace APSIM.PerformanceTests.Service.Controllers
                     }
 
                     // Get file count for this pull request.
-                    strSQL = "SELECT COUNT(*) AS CurrentFileCount" + Environment.NewLine +
-                                "FROM[APSIM.PerformanceTests].[dbo].[ApsimFiles] af" + Environment.NewLine +
-                                "WHERE af.[PullRequestId] = @PullRequestID ";
+                    strSQL = @"SELECT COUNT(*) as CurrentFileCount
+FROM [APSIM.PerformanceTests].[dbo].[PredictedObservedDetails], [APSIM.PerformanceTests].[dbo].[ApsimFiles] af
+WHERE [ApsimFilesID] = af.[ID]
+AND af.[PullRequestId] = @PullRequestID";
                     using (SqlCommand commandES = new SqlCommand(strSQL, sqlCon))
                     {
                         commandES.CommandType = CommandType.Text;


### PR DESCRIPTION
There are really 2 files counts - the number of files, and the total number of predicted/observed tables in those files. We were previously confusing the two numbers and comparing the accepted stats' number of
p/o tables vs the current pull request's number of files.

This raises the question of how this ever worked to begin with...