### PR TITLE
Use same version of NewtonSoft.Json as in apsimx.

### DIFF
--- a/APSIM.PerformanceTests.Collector/App.config
+++ b/APSIM.PerformanceTests.Collector/App.config
@@ -31,7 +31,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-11.0.0.0" newVersion="11.0.0.0"/>
+        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0"/>
       </dependentAssembly>
     </assemblyBinding>
   </runtime>


### PR DESCRIPTION
This is required to match Eric's changes in APSIMInitiative/ApsimX#4274 and get the collector running again.

@hol353 - fyi. Not sure if you get notifications for this repo