### PR TITLE
Fixed bug in missing files display in portal

### DIFF
--- a/APSIM.PerformanceTests.Portal/APSIM.PerformanceTests.Portal/Default.aspx
+++ b/APSIM.PerformanceTests.Portal/APSIM.PerformanceTests.Portal/Default.aspx
@@ -68,7 +68,7 @@
             <asp:Label ID="lblPullRequestId" runat="server" CssClass="SectionTitles" Text=""></asp:Label>
             <br />
             <asp:Label ID="lblMissing" runat="server" CssClass="ScreenDetails, FailedTests" Text=""></asp:Label>
-
+            <asp:Label ID="lblNewFiles" runat="server" CssClass="ScreenDetails, PassedTests" Text=""></asp:Label>
             <asp:GridView ID="gvSimFiles" runat="server" AutoGenerateColumns="false" PageSize="25" AllowPaging="true" AllowSorting="true" 
                 DataKeyNames="PredictedObservedID" 
                 CssClass="Grid2" AlternatingRowStyle-CssClass="alt" PagerStyle-CssClass="pgr"

--- a/APSIM.PerformanceTests.Portal/APSIM.PerformanceTests.Portal/Default.aspx.cs
+++ b/APSIM.PerformanceTests.Portal/APSIM.PerformanceTests.Portal/Default.aspx.cs
@@ -9,7 +9,7 @@ using System.Net.Http;
 using System.Web.UI;
 using System.Web.UI.WebControls;
 using System.Reflection;
-
+using System.Text;
 
 namespace APSIM.PerformanceTests.Portal
 {
@@ -601,10 +601,17 @@ namespace APSIM.PerformanceTests.Portal
             hfPullRequestId.Value = pullRequestId.ToString();
             if (acceptPullRequestId > 0)
             {
-                string errorMessage = ApsimFilesDS.GetFileCountDetails(pullRequestId, acceptPullRequestId);
-                if (errorMessage.Length > 0)
+                List<string> missingTables = ApsimFilesDS.GetMissingTables(pullRequestId, acceptPullRequestId);
+                if (missingTables != null && missingTables.Count > 0)
+                    lblMissing.Text = "Missing FileName.TableName(s): " + string.Join(",", missingTables) + ".";
+
+                List<string> newTables = ApsimFilesDS.GetNewTables(pullRequestId, acceptPullRequestId);
+                if (newTables != null && newTables.Count > 0)
                 {
-                    lblMissing.Text = "Missing FileName.TableName(s): " + errorMessage + ".";
+                    StringBuilder message = new StringBuilder();
+                    message.AppendLine("New predicted/observed tables have been added by this pull request:");
+                    message.AppendLine(string.Join(",", newTables));
+                    lblNewFiles.Text = message.ToString();
                 }
             }
 

--- a/APSIM.PerformanceTests.Portal/APSIM.PerformanceTests.Portal/Default.aspx.designer.cs
+++ b/APSIM.PerformanceTests.Portal/APSIM.PerformanceTests.Portal/Default.aspx.designer.cs
@@ -103,6 +103,15 @@ namespace APSIM.PerformanceTests.Portal {
         protected global::System.Web.UI.WebControls.Label lblMissing;
         
         /// <summary>
+        /// lblNewFiles control.
+        /// </summary>
+        /// <remarks>
+        /// Auto-generated field.
+        /// To modify move field declaration from designer file to code-behind file.
+        /// </remarks>
+        protected global::System.Web.UI.WebControls.Label lblNewFiles;
+        
+        /// <summary>
         /// gvSimFiles control.
         /// </summary>
         /// <remarks>


### PR DESCRIPTION
Previously, we grabbed each p/o table from the accepted stats and each p/o table from the current pull request. If any table name appeared only once in the result, then we displayed an error message that that table was missing from the current pull request.

The problem with this approach is that if the pull request adds a new table, then there would only be one instance of that table name in the result and thus the portal would display an error message saying that this table is missing from the pull request.

I've fixed this so that the error message will only be shown if the table exists in the accepted stats but not in the stats for the current pull request. I've also added another message showing new table names which were added by this pull request.