### PR TITLE
Errors while adding P/O values should be fatal

### DIFF
--- a/APSIM.PerformanceTests.Service/APSIM.PerformanceTests.Service/Controllers/ApsimFilesController.cs
+++ b/APSIM.PerformanceTests.Service/APSIM.PerformanceTests.Service/Controllers/ApsimFilesController.cs
@@ -200,6 +200,7 @@ namespace APSIM.PerformanceTests.Service.Controllers
                     catch (Exception ex)
                     {
                         Utilities.WriteToLogFile("    ERROR:  Checking for existing Pull Requests: " + ex.Message.ToString());
+                        throw;
                     }
 
                     if (pullRequestCount > 0)
@@ -222,6 +223,7 @@ namespace APSIM.PerformanceTests.Service.Controllers
                         catch (Exception ex)
                         {
                             Utilities.WriteToLogFile("    ERROR:  Error Removing original Pull Request Data: " + ex.Message.ToString());
+                            throw;
                         }
                     }
                     sqlConnect.Close();
@@ -267,6 +269,7 @@ namespace APSIM.PerformanceTests.Service.Controllers
                     catch (Exception ex)
                     {
                         Utilities.WriteToLogFile("    ERROR:  Inserting into ApsimFiles failed: " + ex.Message.ToString());
+                        throw;
                     }
 
                     //--------------------------------------------------------------------------------------
@@ -295,6 +298,7 @@ namespace APSIM.PerformanceTests.Service.Controllers
                         catch (Exception ex)
                         {
                             Utilities.WriteToLogFile("    ERROR:  usp_SimulationsInsert failed: " + ex.Message.ToString());
+                            throw;
                         }
                     }
 
@@ -338,7 +342,8 @@ namespace APSIM.PerformanceTests.Service.Controllers
                         }
                         catch (Exception ex)
                         {
-                            Utilities.WriteToLogFile("    ERROR:  INSERT INTO PredictedObservedDetails failed: " + ex.Message.ToString()); 
+                            Utilities.WriteToLogFile("    ERROR:  INSERT INTO PredictedObservedDetails failed: " + ex.Message.ToString());
+                            throw;
                         }
 
 
@@ -438,6 +443,7 @@ namespace APSIM.PerformanceTests.Service.Controllers
                                 catch (Exception ex)
                                 {
                                     Utilities.WriteToLogFile("    ERROR:  Unable to import PredictedObserved Data: " + ErrMessageHelper.ToString() + " - " + ex.Message.ToString());
+                                    throw;
                                 }
                             }   //ObservedColumName.StartsWith("Observed")
                         }   // for (int i = 0; i < poDetail.PredictedObservedData.Columns.Count; i++)


### PR DESCRIPTION
This should make Jenkins run red if the performance tests webservice runs into problems.

There are currently a lot of missing records in the PredictedObservedValues table. These missing records cause graphs to fail to appear on certain pages on the portal. The missing data seems to be due to random discrepancies in the tables in the DB and/or related to bugs in this code. The errors are all written out to a log file which no one checks. I'm hoping that making these errors fatal will force the issue and allow the errors to be fixed.