### PR TITLE
Fixed a bug where R2 was considered in pass/fail status

### DIFF
--- a/APSIM.PerformanceTests.Portal/APSIM.PerformanceTests.Portal/TestsGrids.aspx.cs
+++ b/APSIM.PerformanceTests.Portal/APSIM.PerformanceTests.Portal/TestsGrids.aspx.cs
@@ -534,7 +534,8 @@ namespace APSIM.PerformanceTests.Portal
             string returnStr = string.Empty;
             try
             {
-                returnStr = Math.Round((double)dvalue, digits).ToString();
+                if (dvalue != null)
+                    returnStr = Math.Round((double)dvalue, digits).ToString();
             }
             catch (Exception)
             {
@@ -561,11 +562,13 @@ namespace APSIM.PerformanceTests.Portal
                 //   3642        should become 3642.00  if decPos = 0, then round dvalue to 2 decimal places
                 if (decPos > 0)
                 {
-                    returnStr = Math.Round((double)dvalue, digits - decPos).ToString();
+                    if (dvalue != null)
+                        returnStr = Math.Round((double)dvalue, digits - decPos).ToString();
                 }
                 else
                 {
-                    returnStr = Math.Round((double)dvalue, digits).ToString();
+                    if (dvalue != null)
+                        returnStr = Math.Round((double)dvalue, digits).ToString();
                 }
 
                 if (returnStr.Length >= (digits + 1))

--- a/APSIM.PerformanceTests.Service/APSIM.PerformanceTests.Service/Utilities/DBFunctions.cs
+++ b/APSIM.PerformanceTests.Service/APSIM.PerformanceTests.Service/Utilities/DBFunctions.cs
@@ -370,7 +370,6 @@ namespace APSIM.PerformanceTests.Service
                     string[] testsToConsider = new[] // really?!
                     {
                         "n",
-                        "R2",
                         "RMSE",
                         "NSE",
                         "RSR",


### PR DESCRIPTION
We don't show R2 on the portal, so it shouldn't be part of the pass/fail calculations. Otherwise, you could end up in the scenario where the PR has failed on R2 but passed on everything else, so overall it's flagged as failed, but on the portal everything looks fine because you don't see R2.