### PR TITLE
Don't attempt to import p/o data if both predicted and observed colum…

### DIFF
--- a/APSIM.PerformanceTests.Service/APSIM.PerformanceTests.Service/Controllers/ApsimFilesController.cs
+++ b/APSIM.PerformanceTests.Service/APSIM.PerformanceTests.Service/Controllers/ApsimFilesController.cs
@@ -309,6 +309,9 @@ namespace APSIM.PerformanceTests.Service.Controllers
                         string valueName = observedColumnName.Substring(dotPosn + 1);
                         string predictedColumnName = "Predicted." + valueName;
 
+                        if (!poDetail.Data.Columns.Contains(predictedColumnName))
+                            continue;
+
                         //need to find the first (and then each instance thereafter) of a field name being with Observed,
                         //the get the corresponding Predicted field name, and then create a new table definition based on this
                         //data,


### PR DESCRIPTION
…n don't exist.

@hol353 - as part of my work on the error bars in ApsimX, I want to include observed error data in the p/o table, even if there is no predicted error column to match it. This means that not every observed column will necessarily have a matching predicted column, hence this change.

Edit: working on APSIMInitiative/ApsimX#5341