### PR TITLE
Removed reference to Apsim.ChildrenRecursively()

### DIFF
--- a/APSIM.PerformanceTests.Collector/Program.cs
+++ b/APSIM.PerformanceTests.Collector/Program.cs
@@ -362,7 +362,7 @@ namespace APSIM.PerformanceTests.Collector
             }
 
             List<PredictedObservedDetails> predictedObservedDetailList = new List<PredictedObservedDetails>();
-            foreach (PredictedObserved poModel in Apsim.ChildrenRecursively(sims, typeof(PredictedObserved)))
+            foreach (PredictedObserved poModel in sims.FindAllDescendants<PredictedObserved>())
             {
                 PredictedObservedDetails instance = new PredictedObservedDetails()
                 {


### PR DESCRIPTION
This has been deprecated in favour of model.FindAllDescendants<T>().

This shouldn't be merged until APSIMInitiative/ApsimX#5188 is merged.