### PR TITLE
Revert "Removed reference to Apsim.ChildrenRecursively()"

### DIFF
--- a/APSIM.PerformanceTests.Collector/Program.cs
+++ b/APSIM.PerformanceTests.Collector/Program.cs
@@ -364,7 +364,7 @@ namespace APSIM.PerformanceTests.Collector
             }
 
             List<PredictedObservedDetails> predictedObservedDetailList = new List<PredictedObservedDetails>();
-            foreach (PredictedObserved poModel in sims.FindAllDescendants<PredictedObserved>())
+            foreach (PredictedObserved poModel in Apsim.ChildrenRecursively(sims, typeof(PredictedObserved)))
             {
                 PredictedObservedDetails instance = new PredictedObservedDetails()
                 {


### PR DESCRIPTION
This reverts commit 1de61dcebf9687a35219a98838cd9d36a2943eb3.

All ApsimX pull requests (except 5188) will fail in the performance tests until this is merged.