### PR TITLE
Fixed a few bugs in stats calculations

### DIFF
--- a/APSIM.POStats.Portal/Pages/Index.cshtml
+++ b/APSIM.POStats.Portal/Pages/Index.cshtml
@@ -108,7 +108,7 @@
 
                             <td class="stats-cell">&nbsp;@Html.Raw(IndexModel.EmitNumber(@variable.CurrentRSR, 3, 0, isAccepted: false))</td>
                             <td class="stats-cell">&nbsp;@Html.Raw(IndexModel.EmitNumber(@variable.AcceptedRSR, 3, 0, isAccepted: true))</td>
-                            <td class="stats-tick">@Html.Raw(IndexModel.EmitTickCross(variable.RSRStatus))@VariableFunctions.RSRRating(variable.AcceptedNSE)</td>
+                            <td class="stats-tick">@Html.Raw(IndexModel.EmitTickCross(variable.RSRStatus))@VariableFunctions.RSRRating(variable.AcceptedRSR)</td>
                         </tr>
                     }
                 }


### PR DESCRIPTION
Unsure how the percentdifference variables were supposed to be calculated previously....looks like they were always set to nan? If so, I'm not sure why the system is actually working.