### PR TITLE
90 Update github action to use .net 8.0 for other PR

### DIFF
--- a/.github/workflows/buildandtest.yml
+++ b/.github/workflows/buildandtest.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        dotnet-version: [ '7.0.x' ]
+        dotnet-version: [ '8.0.x' ]
 
     steps:
       - name: Checkout Pull request branch


### PR DESCRIPTION
Working on #90 

This just updates the github action dependencies so that the actual update to .net 8 will be able to run in the tests.